### PR TITLE
fix the 1st diagram tooltip (was hidden by overflow)

### DIFF
--- a/pyscada/hmi/static/pyscada/css/pyscada/pyscada-theme.css
+++ b/pyscada/hmi/static/pyscada/css/pyscada/pyscada-theme.css
@@ -179,7 +179,6 @@ html,body {
 }
 
 #content {
-	overflow:auto;
 	padding-bottom:50px;
 }
 


### PR DESCRIPTION
"overflow: auto;" caused the tooltip to make the parent (setted as absolute) overflow below the navbar, therefore hiding the tooltip of the first chart.
As me tried adding some other charts below, the general behaviour of the application doesn't seem to be impacted. 